### PR TITLE
Add blog functionality to documentation site

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -9,7 +9,8 @@ export default defineConfig({
     nav: [
       { text: 'Home', link: '/' },
       { text: 'Guide', link: '/guide/introduction' },
-      { text: 'Reference', link: '/reference/cli' }
+      { text: 'Reference', link: '/reference/cli' },
+      { text: 'Blog', link: '/blog/' }
     ],
 
     sidebar: [

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,3 @@
+import DefaultTheme from 'vitepress/theme'
+
+export default DefaultTheme

--- a/docs/.vitepress/theme/posts.data.mts
+++ b/docs/.vitepress/theme/posts.data.mts
@@ -1,0 +1,16 @@
+import { createContentLoader } from 'vitepress'
+
+export default createContentLoader('blog/posts/*.md', {
+  transform(rawData) {
+    return rawData
+      .map(({ url, frontmatter }) => ({
+        url,
+        title: frontmatter.title,
+        description: frontmatter.description,
+        date: frontmatter.date,
+        author: frontmatter.author,
+        tags: frontmatter.tags
+      }))
+      .sort((a, b) => new Date(b.date) - new Date(a.date))
+  }
+})

--- a/docs/blog/index.md
+++ b/docs/blog/index.md
@@ -1,0 +1,86 @@
+---
+layout: page
+title: Blog
+description: Latest updates, announcements, and insights about Fabrik
+---
+
+<script setup>
+import { data as posts } from '../.vitepress/theme/posts.data.mts'
+</script>
+
+# Blog
+
+Latest updates and insights about Fabrik's development and features.
+
+<div class="blog-posts">
+  <article v-for="post in posts" :key="post.url" class="post-item">
+    <h2><a :href="post.url">{{ post.title }}</a></h2>
+    <div class="post-meta">
+      <time :datetime="post.date">{{ new Date(post.date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' }) }}</time>
+      <span v-if="post.author"> by {{ post.author }}</span>
+    </div>
+    <p>{{ post.description }}</p>
+    <div class="post-tags" v-if="post.tags && post.tags.length">
+      <span v-for="tag in post.tags" :key="tag" class="tag">{{ tag }}</span>
+    </div>
+  </article>
+</div>
+
+<style scoped>
+.blog-posts {
+  margin-top: 2rem;
+}
+
+.post-item {
+  margin-bottom: 3rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--vp-c-divider);
+}
+
+.post-item:last-child {
+  border-bottom: none;
+}
+
+.post-item h2 {
+  margin: 0 0 0.5rem 0;
+  border-top: none;
+}
+
+.post-item h2 a {
+  color: var(--vp-c-brand-1);
+  text-decoration: none;
+}
+
+.post-item h2 a:hover {
+  text-decoration: underline;
+}
+
+.post-meta {
+  color: var(--vp-c-text-2);
+  font-size: 0.9rem;
+  margin-bottom: 0.75rem;
+}
+
+.post-meta time {
+  font-weight: 500;
+}
+
+.post-item p {
+  margin: 0 0 1rem 0;
+  line-height: 1.6;
+}
+
+.post-tags {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.tag {
+  background: var(--vp-c-default-soft);
+  color: var(--vp-c-text-2);
+  padding: 0.25rem 0.75rem;
+  border-radius: 12px;
+  font-size: 0.85rem;
+}
+</style>

--- a/docs/blog/posts/2025-01-15-introducing-fabrik.md
+++ b/docs/blog/posts/2025-01-15-introducing-fabrik.md
@@ -1,0 +1,78 @@
+---
+title: Introducing Fabrik - Multi-Layer Build Cache Infrastructure
+description: Fabrik is a new foundation for build caching, designed to provide transparent, high-performance caching across different environments.
+date: 2025-01-15
+author: Tuist Team
+tags:
+  - announcement
+  - build-cache
+  - infrastructure
+---
+
+# Introducing Fabrik
+
+We're excited to introduce **Fabrik**, a multi-layer build cache infrastructure designed to optimize build performance across different environments. Fabrik supports various build systems including Gradle, Bazel, Nx, TurboRepo, and compiler caches like sccache.
+
+## What is Fabrik?
+
+Fabrik provides a transparent, high-performance caching hierarchy that works seamlessly across local development, CI environments, and cloud infrastructure. Think of it as the foundational layer for build caching - similar to how Postgres is to Supabase, Fabrik is to Tuist.
+
+## Key Features
+
+### Three-Layer Caching Strategy
+
+Fabrik implements a smart caching hierarchy:
+
+1. **Layer 1: Local Cache** - Fast, ephemeral caching bound to your build process
+2. **Layer 2: Regional Cache** - Dedicated instances for your team, deployed in your preferred region
+3. **Layer 3: Cloud Storage** - Permanent S3-backed storage with no eviction
+
+### Build System Support
+
+Fabrik works with your existing build tools:
+
+- **Gradle** - HTTP REST API integration
+- **Bazel** - gRPC Remote Execution API
+- **Nx & TurboRepo** - HTTP-based remote caching
+- **sccache** - S3-compatible API for Rust/Cargo builds
+
+### Zero-Configuration CI
+
+Fabrik automatically detects your CI environment and configures itself:
+
+- GitHub Actions support out of the box
+- GitLab CI integration (coming soon)
+- Local development fallback to filesystem
+
+## Getting Started
+
+Install Fabrik and start caching your builds:
+
+```bash
+# For Bazel projects
+fabrik bazel -- build //...
+
+# For Gradle projects
+fabrik gradle build
+
+# Run as a daemon for local development
+fabrik daemon
+```
+
+## What's Next?
+
+We're actively developing Fabrik with a focus on:
+
+- Multi-region distribution and replication
+- Advanced eviction policies
+- Enhanced observability with distributed tracing
+- Support for additional build systems
+
+Stay tuned for more updates, and check out our [documentation](/guide/introduction) to learn more!
+
+## Learn More
+
+- [Read the introduction guide](/guide/introduction)
+- [Check out build system integrations](/build-systems/bazel)
+- [View the API reference](/reference/api)
+- [Contribute on GitHub](https://github.com/tuist/fabrik)


### PR DESCRIPTION
## Summary

This PR enables blog functionality in the VitePress documentation site, allowing the Fabrik team to publish updates, announcements, and insights.

## Changes

- **Blog Navigation**: Added "Blog" link to the main navigation bar
- **Blog Index Page**: Created `/blog/` page that automatically lists all blog posts sorted by date
- **Content Loader**: Implemented VitePress data loader (`posts.data.mts`) to generate post metadata
- **Theme Support**: Added theme index file to support custom features
- **Example Post**: Included an introductory blog post about Fabrik

## Technical Details

The blog uses VitePress's content loader API to:
1. Scan all markdown files in `docs/blog/posts/`
2. Extract frontmatter metadata (title, date, description, author, tags)
3. Sort posts by date (newest first)
4. Dynamically render the post list

## Blog Post Structure

Blog posts are created as markdown files in `docs/blog/posts/` with frontmatter:

```yaml
---
title: Post Title
description: Brief description
date: 2025-01-15
author: Author Name
tags:
  - tag1
  - tag2
---
```

## Testing

- ✅ Built successfully with `pnpm run docs:build`
- ✅ Blog index page displays correctly
- ✅ Blog navigation link works
- ✅ Example post renders properly

## What's Next

The blog is now ready for content! Future blog posts can be added by simply creating new markdown files in `docs/blog/posts/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)