### PR TITLE
feat: implement config auto-discovery and env var support across all CLI commands

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -388,7 +388,7 @@ pub enum ConfigCommands {
     /// Show effective configuration (merged from all sources)
     Show {
         /// Config file path
-        #[arg(short = 'c', long)]
+        #[arg(short = 'c', long, env = "FABRIK_CONFIG")]
         config: Option<String>,
     },
 }
@@ -396,22 +396,26 @@ pub enum ConfigCommands {
 #[derive(Parser, Debug)]
 pub struct HealthArgs {
     /// URL of Fabrik instance to check
-    #[arg(long)]
+    #[arg(long, env = "FABRIK_HEALTH_URL")]
     pub url: Option<String>,
 
     /// Request timeout
-    #[arg(long, default_value = "5s")]
+    #[arg(long, default_value = "5s", env = "FABRIK_HEALTH_TIMEOUT")]
     pub timeout: String,
 
     /// Output format (text, json)
-    #[arg(long, default_value = "text")]
+    #[arg(long, default_value = "text", env = "FABRIK_HEALTH_FORMAT")]
     pub format: String,
 }
 
 #[derive(Parser, Debug)]
 pub struct DoctorArgs {
+    /// Config file path
+    #[arg(short = 'c', long, env = "FABRIK_CONFIG")]
+    pub config: Option<String>,
+
     /// Verbose output
-    #[arg(short, long)]
+    #[arg(short, long, env = "FABRIK_VERBOSE")]
     pub verbose: bool,
 }
 

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -57,13 +57,11 @@ fn generate(template: &str) -> Result<()> {
 }
 
 fn show(config_path: Option<String>) -> Result<()> {
+    use crate::config_discovery::load_config_with_discovery;
+
     info!("Showing effective configuration");
 
-    let config = if let Some(path) = config_path {
-        FabrikConfig::from_file(path)?
-    } else {
-        FabrikConfig::default()
-    };
+    let config = load_config_with_discovery(config_path.as_deref())?.unwrap_or_default();
 
     println!("Effective Configuration:\n");
     println!("{}", toml::to_string_pretty(&config)?);

--- a/src/commands/exec.rs
+++ b/src/commands/exec.rs
@@ -12,7 +12,6 @@ use crate::bazel::{
     BazelActionCacheService, BazelByteStreamService, BazelCapabilitiesService, BazelCasService,
 };
 use crate::cli::ExecArgs;
-use crate::config::FabrikConfig;
 use crate::config_discovery::populate_build_tool_env_vars;
 use crate::http::HttpServer;
 use crate::merger::MergedExecConfig;
@@ -20,16 +19,14 @@ use crate::storage;
 use tonic::transport::Server;
 
 pub async fn run(args: ExecArgs) -> Result<()> {
+    use crate::config_discovery::load_config_with_discovery;
+
     if args.command.is_empty() {
         anyhow::bail!("No command specified. Usage: fabrik exec -- <command>");
     }
 
-    // Load config file if specified
-    let file_config = if let Some(config_path) = &args.config {
-        Some(FabrikConfig::from_file(config_path)?)
-    } else {
-        None
-    };
+    // Load config file with auto-discovery
+    let file_config = load_config_with_discovery(args.config.as_deref())?;
 
     // Merge configuration
     let config = MergedExecConfig::merge(&args, file_config);

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -18,11 +18,21 @@ use crate::script::{
 use crate::storage::default_cache_dir;
 
 pub async fn run(args: &RunArgs) -> Result<()> {
-    // Initialize cache directory
+    use crate::config_discovery::load_config_with_discovery;
+
+    // Load config file with auto-discovery
+    let file_config = load_config_with_discovery(args.config.as_deref())?;
+
+    // Initialize cache directory (CLI arg > config file > default)
     let cache_dir = args
         .config_cache_dir
         .as_deref()
         .map(std::path::PathBuf::from)
+        .or_else(|| {
+            file_config
+                .as_ref()
+                .map(|c| std::path::PathBuf::from(&c.cache.dir))
+        })
         .unwrap_or_else(default_cache_dir);
 
     // Handle script management operations

--- a/src/commands/server.rs
+++ b/src/commands/server.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use tracing::info;
 
 use crate::cli::ServerArgs;
-use crate::config::FabrikConfig;
 use crate::merger::MergedServerConfig;
 use crate::storage::FilesystemStorage;
 use crate::xcode::proto::cas::casdb_service_server::CasdbServiceServer;
@@ -11,12 +10,10 @@ use crate::xcode::proto::keyvalue::key_value_db_server::KeyValueDbServer;
 use crate::xcode::{CasService, KeyValueService};
 
 pub async fn run(args: ServerArgs) -> Result<()> {
-    // Load config file if specified
-    let file_config = if let Some(config_path) = &args.config {
-        Some(FabrikConfig::from_file(config_path)?)
-    } else {
-        None
-    };
+    use crate::config_discovery::load_config_with_discovery;
+
+    // Load config file with auto-discovery
+    let file_config = load_config_with_discovery(args.config.as_deref())?;
 
     // Merge configuration
     let config = MergedServerConfig::merge(&args, file_config);

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,14 +44,10 @@ async fn main() -> Result<()> {
         Commands::Kv(args) => commands::kv::run(&args).await,
         Commands::Auth(args) => {
             use cli::AuthCommand;
-            use config::FabrikConfig;
+            use config_discovery::load_config_with_discovery;
 
-            // Load config
-            let config = if let Some(config_path) = &args.config {
-                FabrikConfig::from_file(config_path)?
-            } else {
-                FabrikConfig::default()
-            };
+            // Load config with auto-discovery
+            let config = load_config_with_discovery(args.config.as_deref())?.unwrap_or_default();
 
             // Dispatch to auth subcommand
             match &args.command {


### PR DESCRIPTION
## Summary

This PR ensures all CLI commands follow the documented conventions for configuration and environment variable support:

### 1. Config File Auto-Discovery ✨

Added automatic config discovery to all commands by:
- Created `load_config_with_discovery()` helper function in `config_discovery.rs`
- Commands now auto-discover `fabrik.toml` by traversing up directory tree from cwd
- Fallback to `~/.config/fabrik/config.toml` if no project config found
- **Commands updated:** daemon, server, exec, run, auth, config show

**Before:**
```bash
# Only worked with explicit --config flag
fabrik daemon --config fabrik.toml
```

**After:**
```bash
# Auto-discovers fabrik.toml from current or parent directories
cd ~/myproject/src
fabrik daemon  # ✅ Finds ../fabrik.toml automatically
```

### 2. Environment Variable Support 🔧

Added missing environment variable support:

**Health command:**
- `FABRIK_HEALTH_URL` for `--url`
- `FABRIK_HEALTH_TIMEOUT` for `--timeout`
- `FABRIK_HEALTH_FORMAT` for `--format`

**Doctor command:**
- `FABRIK_CONFIG` for `--config`
- `FABRIK_VERBOSE` for `--verbose`

**Config show:**
- `FABRIK_CONFIG` for `--config`

### 3. Consistency Improvements 📋

- All commands now follow same precedence: **CLI args > Env vars > Config file**
- Consistent use of `FABRIK_*` and `FABRIK_CONFIG_*` prefixes
- Updated `CLAUDE.md` with comprehensive documentation and examples

## Testing

✅ **Config auto-discovery:**
```bash
# Created test config in /tmp/fabrik-test/fabrik.toml
cd /tmp/fabrik-test/subdir
fabrik config show  # ✅ Found ../fabrik.toml
```

✅ **Environment variable overrides:**
```bash
env FABRIK_CONFIG=/tmp/custom-config.toml fabrik config show
# ✅ Loaded custom config instead of auto-discovered one

env FABRIK_HEALTH_URL=http://example.com:8080 fabrik health
# ✅ Used env var URL
```

✅ **Code quality:**
- `cargo fmt` - ✅ Passed
- `cargo clippy --all-targets --all-features -- -D warnings` - ✅ Passed (zero warnings)

## Impact

**Fixes discrepancy:** Only `activate` and `doctor` commands implemented auto-discovery, but the feature was documented as working for **all** commands in `CLAUDE.md`.

**Improves UX:** Users no longer need to specify `--config` for every command - it "just works" like documented.

**Better compliance:** All commands now fully support the documented conventions:
- ✅ Config file discovery via directory traversal
- ✅ Environment variable overrides for all flags
- ✅ Proper precedence order

## Files Changed

- `src/config_discovery.rs` - Added helper function
- `src/commands/daemon.rs` - Implemented auto-discovery
- `src/commands/server.rs` - Implemented auto-discovery
- `src/commands/exec.rs` - Implemented auto-discovery
- `src/commands/run.rs` - Implemented auto-discovery + config loading
- `src/commands/config.rs` - Implemented auto-discovery for show command
- `src/main.rs` - Implemented auto-discovery for auth command
- `src/cli.rs` - Added env var support to health/doctor/config
- `CLAUDE.md` - Updated documentation with examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)